### PR TITLE
normalize path to unix-style directory separator,…

### DIFF
--- a/src/Section.php
+++ b/src/Section.php
@@ -15,8 +15,10 @@ use function implode;
 use function preg_match;
 use function preg_match_all;
 use function sprintf;
+use function str_replace;
 
 use const PREG_SET_ORDER;
+
 
 final class Section
 {
@@ -72,7 +74,7 @@ final class Section
         // normalize path to unix-style directory separator,
         // because the glob pattern assumes linux-style directory separators
         $path = str_replace(DIRECTORY_SEPARATOR, '/', $path);
-        
+
         if (preg_match('#{(.*)}#', $this->glob) === 1) {
             return $this->matchesWithCurlBracesExpansion($path);
         }

--- a/src/Section.php
+++ b/src/Section.php
@@ -19,7 +19,6 @@ use function str_replace;
 
 use const PREG_SET_ORDER;
 
-
 final class Section
 {
     /** @var string */

--- a/src/Section.php
+++ b/src/Section.php
@@ -73,7 +73,7 @@ final class Section
     {
         // normalize path to unix-style directory separator,
         // because the glob pattern assumes linux-style directory separators
-        $path = str_replace(DIRECTORY_SEPARATOR, '/', $path);
+        $path = str_replace('\\', '/', $path);
 
         if (preg_match('#{(.*)}#', $this->glob) === 1) {
             return $this->matchesWithCurlBracesExpansion($path);

--- a/src/Section.php
+++ b/src/Section.php
@@ -67,6 +67,10 @@ final class Section
 
     public function matches(string $path) : bool
     {
+        // normalize path to unix-style directory separator,
+        // because the glob pattern assumes linux-style directory separators
+        $path = str_replace(DIRECTORY_SEPARATOR, '/', $path);
+        
         if (preg_match('#{(.*)}#', $this->glob) === 1) {
             return $this->matchesWithCurlBracesExpansion($path);
         }

--- a/tests/SectionTest.php
+++ b/tests/SectionTest.php
@@ -27,6 +27,21 @@ class SectionTest extends TestCase
         $this->assertFalse(isset($section->tab_width));
     }
 
+    public function testMatchingWindowsPath() : void
+    {
+        $section = new Section(
+            '**/',
+            '*.php',
+            [
+                'indent_size' => '4',
+                'indent_style' => 'space',
+            ],
+            new Factory()
+        );
+
+        $this->assertTrue($section->matches('my\\composer.php'));
+    }
+
     public function testGetMissingDeclaration() : void
     {
         $section = new Section(


### PR DESCRIPTION
…because the [glob pattern assumes linux-style directory separators](https://github.com/idiosyncratic-code/editorconfig-php/blob/50f742daee8b7a632b795f5927d8d88c43dd3a4f/src/EditorConfigFile.php#L134)

closes https://github.com/idiosyncratic-code/editorconfig-php/issues/13